### PR TITLE
Updating node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   capitalized:
     description: The input string, with any alphabetical characters lowercase, except for the first character, which is uppercased
 runs:
-  using: node12
+  using: node16
   main: index.js


### PR DESCRIPTION
👋 
Github as depricated the use of `node12`, [as explained here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) så this PR updates the runtime from `node12` to `node16`.