### PR TITLE
Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   capitalized:
     description: The input string, with any alphabetical characters lowercase, except for the first character, which is uppercased
 runs:
-  using: node16
+  using: node20
   main: index.js


### PR DESCRIPTION
I got the following message in one of my projects:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ASzc/change-string-case-action@v5, actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
